### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 このプロジェクトは、VOICEVOXエンジンと連携して音声合成やスピーカー情報の取得ができるMCP（Model Context Protocol）サーバーです。TypeScriptで実装されており、MCP SDKを利用しています。
 
+<a href="https://glama.ai/mcp/servers/@Yuki10Kobayashi/voicevox-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Yuki10Kobayashi/voicevox-mcp/badge" alt="VOICEVOX Server MCP server" />
+</a>
+
 # 機能
 - VOICEVOXエンジンのスピーカー情報取得（/speakers）
 - 指定したスピーカーでテキストを音声合成し、ローカルで再生（/speak）


### PR DESCRIPTION
This PR adds a badge for the [VOICEVOX MCP Server](https://glama.ai/mcp/servers/@Yuki10Kobayashi/voicevox-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Yuki10Kobayashi/voicevox-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Yuki10Kobayashi/voicevox-mcp/badge" alt="VOICEVOX Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.